### PR TITLE
Update REST API documentation link to the Clumio REST API page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ func main() {
 	res, cerr := handler.ListPolicyDefinitions(nil, nil)
 }
 ```
-The REST API documentation describes all the available APIs and can be accessed from the help section in the top right corner of the Clumio UI.
+The REST API documentation describes all the available APIs and can be accessed from [here](https://api.commvault.com/docs/latest/api/cv/ClumioAPIs/clumio-rest-api/).


### PR DESCRIPTION
Points the README's REST API documentation reference to the [Clumio REST API page](https://api.commvault.com/docs/latest/api/cv/ClumioAPIs/clumio-rest-api/) instead of the outdated "help section in the top right corner of the Clumio UI" wording.